### PR TITLE
autoloading define-keys hangs emacs on startup …

### DIFF
--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -416,8 +416,10 @@ the *BBDB* buffer."
     (kill-new (bbdb-vcard-from (bbdb-current-record nil)))
     (message "Saved record as vCard")))
 
-(define-key bbdb-mode-map [(v)] 'bbdb-vcard-export)
-(define-key bbdb-mode-map [(V)] 'bbdb-vcard-export-to-kill-ring)
+(defun bbdb-vcard-default-keybindings ()
+  "Assign the default bbdb-vcard keybindings."
+  (define-key bbdb-mode-map [(v)] 'bbdb-vcard-export)
+  (define-key bbdb-mode-map [(V)] 'bbdb-vcard-export-to-kill-ring))
 
 (defun bbdb-vcard-iterate-vcards (vcard-processor vcards)
   "Apply VCARD-PROCESSOR successively to each vCard in string VCARDS.

--- a/bbdb-vcard.texi
+++ b/bbdb-vcard.texi
@@ -31,10 +31,32 @@ Import and export of vCards as defined in RFC 2425 and RFC 2426
 to/from The Insidious Big Brother Database (BBDB).
 
 @menu
+* Setup::
 * Import Contacts::
 * Export Contacts::
 * Implementation::
 @end menu
+
+@node Setup
+@chapter Setup
+
+Put this file and file vcard.el into your @code{load-path} and add the
+following line to your Emacs initialization file:
+
+@lisp
+(require 'bbdb-vcard)
+(bbdb-vcard-default-keybindings) ; optional, binds v/V keys in bbdb
+@end lisp
+
+@noindent If you use @code{use-package} for deferred loading, you may prefer:
+
+@lisp
+(use-package bbdb-vcard
+  :ensure t    ; get it from Melpa
+  :after bbdb  ; defer until bbdb loaded
+  :config      ; bind v/V keys
+  (bbdb-vcard-default-keybindings))
+@end lisp
 
 @node Import Contacts
 @chapter Import Contacts


### PR DESCRIPTION
… when bbdb-vcard is installed through elpa.

I'm not sure what the right fix is here; manually doing define-key after (require 'bbdb) works for me though.
