### PR TITLE
Avoid name clashes with the GNU ELPA's vcard.el.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ command will install bbdb-vcard (and its dependencies).
 
 First, checkout the repository:
 ```sh
-git clone git://github.com/vgeddes/bbdb-vcard.git
+git clone https://github.com/tohojo/bbdb-vcard.git
 ```
 
 Use the included Makefile to compile and install the package. By default

--- a/bbdb-vcard-vcard21.el
+++ b/bbdb-vcard-vcard21.el
@@ -1,4 +1,4 @@
-;;; vcard.el --- vcard parsing and display routines
+;;; bbdb-vcard-vcard21.el --- vcard parsing and display routines
 
 ;; Copyright (C) 1997, 1999, 2000 Noah S. Friedman
 
@@ -700,6 +700,5 @@ presentation buffer."
       (setq strings (cdr strings)))
     maxlen))
 
-(provide 'vcard)
-
-;;; vcard.el ends here.
+(provide 'bbdb-vcard-vcard21)
+;;; bbdb-vcard-vcard21.el ends here

--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -1003,8 +1003,9 @@ return `nil'."
               (bbdb-vcard-escape-strings (bbdb-address-state address)))
          ";" (bbdb-vcard-vcardize-address-element
               (bbdb-vcard-escape-strings (bbdb-address-postcode address)))
-         ";" (bbdb-vcard-vcardize-address-element
-              (bbdb-vcard-escape-strings (bbdb-address-country address)))))
+         ";" (when (bbdb-address-country address)
+	       (bbdb-vcard-vcardize-address-element
+		(bbdb-vcard-escape-strings (bbdb-address-country address))))))
       (when url
         (bbdb-vcard-insert-vcard-element "URL" url))
       (when notes

--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -793,10 +793,7 @@ Extend existing BBDB records where possible."
                     (setq vcard-tels-backup t))
                   nil))
            ;; No existing record found; make a fresh one:
-           (let ((record (make-vector bbdb-record-length nil)))
-             (bbdb-record-set-cache record (make-vector bbdb-cache-length nil))
-             (run-hook-with-args 'bbdb-create-hook record)
-             (bbdb-change-record record t t)
+           (let ((record (bbdb-empty-record)))
              record))))
     (when name-need-manual-edit-p
       (message (format "Need edit by hand: %S in your *contacts source* and %S in your *BBDB buffer*."

--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -117,7 +117,7 @@
 
 (require 'cl-lib)
 (require 'bbdb)
-(require 'vcard)
+(require 'bbdb-vcard-vcard21)
 (require 'bbdb-com)
 
 (defconst bbdb-vcard-version "0.4.1"

--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -8,7 +8,7 @@
 ;;         Steve Purcell
 ;;         Vincent Geddes <vincent.geddes@gmail.com>
 ;; Keywords: data calendar mail news
-;; URL: http://github.com/vgeddes/bbdb-vcard
+;; URL: https://github.com/tohojo/bbdb-vcard
 ;; Package-Requires: ((bbdb "3.0"))
 ;; Version: 0.4.1
 


### PR DESCRIPTION
There is a module with the same name at GNU ELPA. Since this package does not really intend to provide vcard.el, rename to avoid name clashes.