### PR TITLE
Fix "replace-match subexpression does not exist: 1"

### DIFF
--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -433,7 +433,7 @@ When VCARDS is nil, return nil.  Otherwise, return t."
     ;; Change CRLF into CR if necessary, dealing with inconsistent line
     ;; endings.
     (while (re-search-forward "\r\n" nil t)
-      (replace-match "\n" nil nil nil 1))
+      (replace-match "\n"))
     (let ((vcards-normalized (bbdb-vcard-unfold-lines (buffer-string)))
           (results nil))
       (erase-buffer)


### PR DESCRIPTION
For me (Emacs 27.1) importing of VCARDS is failing with the error

  replace-match subexpression does not exist: 1

My interpretation of the documentation of `replace-match` is that the
fifth argument should only be used when there are subexpressions in
the search string (something between '\(' and '\)').