### PR TITLE
Anticipate record with address lacking country

### DIFF
--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -1003,8 +1003,9 @@ return `nil'."
               (bbdb-vcard-escape-strings (bbdb-address-state address)))
          ";" (bbdb-vcard-vcardize-address-element
               (bbdb-vcard-escape-strings (bbdb-address-postcode address)))
-         ";" (bbdb-vcard-vcardize-address-element
-              (bbdb-vcard-escape-strings (bbdb-address-country address)))))
+         ";" (when (bbdb-address-country address)
+	       (bbdb-vcard-vcardize-address-element
+		(bbdb-vcard-escape-strings (bbdb-address-country address))))))
       (when url
         (bbdb-vcard-insert-vcard-element "URL" url))
       (when notes


### PR DESCRIPTION
- if record is coming from a snarf, there is no guarantee country is specified

- if country isn't specified, bbdb-vcard-vcardize-address-element shouldn't be passed NIL